### PR TITLE
Fix: MySQL json path vulnerability

### DIFF
--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -474,10 +474,11 @@ const QueryGenerator = {
      *
      * https://bugs.mysql.com/bug.php?id=81896
      */
+
     const paths = _.toPath(path).map(subPath => Utils.addTicks(subPath, '"'));
-    const pathStr = `${['$'].concat(paths).join('.')}`;
+    const pathStr = this.escape(['$'].concat(paths).join('.'));
     const quotedColumn = this.isIdentifierQuoted(column) ? column : this.quoteIdentifier(column);
-    return `(${quotedColumn}->>'${pathStr}')`;
+    return `(${quotedColumn}->>${pathStr})`;
   },
 
   /**


### PR DESCRIPTION
### Summary:
https://snyk.io/vuln/SNYK-JS-SEQUELIZE-450221

MySQL és MariaDB dialect használata során JSON path alapú query feltételek nem kerültek escapelésre. Az ilyen queryk bizonyos körülmények között sql injection támadási felületet biztosítottak.

Általunk használt sequelize verzió nem támogatja a MariaDB-t, csak a MySQL dialect érint minket.

A fixet az alábbi official repoból származó commit alapján készítettem:
https://github.com/sequelize/sequelize/commit/a72a3f5#diff-185469cea2079250f6cac5b57384909522b66a45fbd6c1180169f89b5ac0befa

POC, amivel teszteltem a megoldást:
```
const Sequelize = require('sequelize');
const sequelize = new Sequelize('test', 'root', 'root', {
  host: 'localhost',
  port: '3306',
  dialect: 'mysql'
});

class Project extends Sequelize.Model {}

Project.init({
  name: Sequelize.STRING,
  target: Sequelize.JSON,
}, {
  sequelize,
  tableName: 'projects',
});

(async () => {
  await sequelize.sync();

  console.log(await Project.findAll({
    where: {
      target: {
        "a') AS DECIMAL) = 1 UNION SELECT VERSION(); -- ": 1
      }
    },
    attributes: ['name'],
    raw: true,
  }));
})();
```

### References:

**YouTrack ticket(s):**

https://youtrack.techteamer.com/youtrack/issue/FKC-92

**Related PR(s):**

`nothing`
