### PR TITLE
FKITDEV-141: fix insert/update blob field with null value in mssql

### DIFF
--- a/src/dialects/abstract/query-generator.js
+++ b/src/dialects/abstract/query-generator.js
@@ -121,6 +121,7 @@ class QueryGenerator {
     const quotedTable = this.quoteTable(table);
     const bindParam = options.bindParam === undefined ? this.bindParam(bind) : options.bindParam;
     const returnAttributes = [];
+    const attrTypes = [];
     let query;
     let valueQuery = '';
     let emptyQuery = '';
@@ -179,8 +180,10 @@ class QueryGenerator {
             fields.splice(-1, 1);
           } else if (this._dialect.supports.DEFAULT) {
             values.push('DEFAULT');
+            attrTypes.push(modelAttributes[key].type);
           } else {
             values.push(this.escape(null));
+            attrTypes.push(modelAttributes[key].type);
           }
         } else {
           if (modelAttributeMap && modelAttributeMap[key] && modelAttributeMap[key].autoIncrement === true) {
@@ -192,6 +195,7 @@ class QueryGenerator {
           } else {
             values.push(this.format(value, modelAttributeMap && modelAttributeMap[key] || undefined, { context: 'INSERT' }, bindParam));
           }
+          attrTypes.push(modelAttributes[key].type);
         }
       }
     }
@@ -302,6 +306,7 @@ class QueryGenerator {
     const result = { query };
     if (options.bindParam !== false) {
       result.bind = bind;
+      result.attrTypes = attrTypes;
     }
 
     return result;
@@ -439,6 +444,7 @@ class QueryGenerator {
 
     const values = [];
     const bind = [];
+    const attrTypes = [];
     const modelAttributeMap = {};
     let outputFragment = '';
     let tmpTable = ''; // tmpTable declaration for trigger
@@ -498,6 +504,7 @@ class QueryGenerator {
       }
 
       const value = attrValueHash[key];
+      attrTypes.push(attributes[key].type);
 
       if (value instanceof Utils.SequelizeMethod || options.bindParam === false) {
         values.push(`${this.quoteIdentifier(key)}=${this.escape(value, modelAttributeMap && modelAttributeMap[key] || undefined, { context: 'UPDATE' })}`);
@@ -517,6 +524,7 @@ class QueryGenerator {
     const result = { query };
     if (options.bindParam !== false) {
       result.bind = bind;
+      result.attrTypes = attrTypes;
     }
     return result;
   }

--- a/src/dialects/mssql/query.js
+++ b/src/dialects/mssql/query.js
@@ -23,7 +23,7 @@ class Query extends AbstractQuery {
     return 'id';
   }
 
-  getSQLTypeFromJsType(value, TYPES) {
+  getSQLTypeFromJsType(value, TYPES, attrType) {
     const paramType = { type: TYPES.NVarChar, typeOptions: {}, value };
     if (typeof value === 'number') {
       if (Number.isInteger(value)) {
@@ -47,13 +47,13 @@ class Query extends AbstractQuery {
     } else if (typeof value === 'boolean') {
       paramType.type = TYPES.Bit;
     }
-    if (Buffer.isBuffer(value)) {
+    if (Buffer.isBuffer(value) || value === null && attrType && attrType.key === 'BLOB') {
       paramType.type = TYPES.VarBinary;
     }
     return paramType;
   }
 
-  async _run(connection, sql, parameters, errStack) {
+  async _run(connection, sql, parameters, errStack, attrTypes) {
     this.sql = sql;
     const { options } = this;
 
@@ -79,7 +79,8 @@ class Query extends AbstractQuery {
 
       if (parameters) {
         _.forOwn(parameters, (value, key) => {
-          const paramType = this.getSQLTypeFromJsType(value, connection.lib.TYPES);
+          const attrType = attrTypes[key] ?? null;
+          const paramType = this.getSQLTypeFromJsType(value, connection.lib.TYPES, attrType);
           request.addParameter(key, paramType.type, value, paramType.typeOptions);
         });
       }
@@ -124,10 +125,10 @@ class Query extends AbstractQuery {
     return this.formatResults(rows, rowCount);
   }
 
-  run(sql, parameters) {
+  run(sql, parameters, attrTypes) {
     const errForStack = new Error();
     return this.connection.queue.enqueue(() =>
-      this._run(this.connection, sql, parameters, errForStack.stack)
+      this._run(this.connection, sql, parameters, errForStack.stack, attrTypes)
     );
   }
 

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -597,6 +597,10 @@ class Sequelize {
         options.bind = sql.bind;
       }
 
+      if (sql.attrTypes !== undefined) {
+        options.attrTypes = sql.attrTypes;
+      }
+
       if (sql.query !== undefined) {
         sql = sql.query;
       }
@@ -616,6 +620,11 @@ class Sequelize {
 
     if (options.bind) {
       [sql, bindParameters] = this.dialect.Query.formatBindParameters(sql, options.bind, this.options.dialect);
+    }
+
+    let attrTypes;
+    if (options.attrTypes) {
+      attrTypes = options.attrTypes;
     }
 
     const checkTransaction = () => {
@@ -647,7 +656,7 @@ class Sequelize {
       try {
         await this.runHooks('beforeQuery', options, query);
         checkTransaction();
-        return await query.run(sql, bindParameters);
+        return await query.run(sql, bindParameters, attrTypes);
       } finally {
         await this.runHooks('afterQuery', options, query);
         if (!options.transaction) {


### PR DESCRIPTION
MSSql-ben ha egy VarBinary mezőt akarunk NULL-ra állítani, akkor azt a sequelize NVarChar mezőként rakja be a DB request-be, erre pedig hibát dob: "Implicit conversion from data type nvarchar to varbinary(max) is not allowed. Use the CONVERT function to run this query."

https://youtrack.techteamer.com/issue/FKITDEV-141/Sequelize-6-ra-frissites-vueross-ben